### PR TITLE
fix(yarn): dont specify yarn engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "engines": {
-    "node": "8.6.0",
-    "yarn": "1.2.1"
+    "node": "8.6.0"
   }
 }


### PR DESCRIPTION
Trying to instant `instantsearch.css` with yarn v1.3.2:

```
➔ yarn add instantsearch.css
yarn add v1.3.2
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
error instantsearch.css@1.0.0: The engine "yarn" is incompatible with this module. Expected version "1.2.1".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```