### PR TITLE
fix(package): remove nodejs fixed version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,5 @@
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   },
-  "engines": {
-    "node": "8.6.0"
-  }
+  "engines": {}
 }


### PR DESCRIPTION
Error while building on CI:

```
2:05:16 PM: error instantsearch.css@1.0.1: The engine "node" is incompatible with this module. Expected version "8.6.0".
2:05:16 PM: error Found incompatible module
```