### PR TITLE
chore: rename site to InstantSearch specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# InstantSearch.css
+# InstantSearch.css and specs
 
 ## Installation
 

--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,3 @@
 baseURL = "http://example.org/"
 languageCode = "en-us"
-title = "InstantSearch.css"
+title = "InstantSearch specs"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
 {{ partial "header.html" . }}
 
 <div class="intro">
-  <h1>CSS library for InstantSearch widgets</h1>
+  <h1>Common specifications for InstantSearch</h1>
   <a href="/widgets/breadcrumb/" class="cta">View widgets</a>
 </div>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <header class="main-header">
-  <h1><a href="/"><strong>InstantSearch</strong>.css</a></h1>
+  <h1><a href="/"><strong>InstantSearch</strong> specs</a></h1>
   <nav>
     <ul>
       <li><a href="/widgets/breadcrumb/">Widgets</a></li>


### PR DESCRIPTION
this changes the name of the website, but not of the published package.

Done in advance of other changes to add widget options and non-rendering widgets.

No need to rename the repo IMO, renaming the site would be nice though