### PR TITLE
fix(single): show message when widget don't have HTML output

### DIFF
--- a/layouts/widget/single.html
+++ b/layouts/widget/single.html
@@ -54,7 +54,7 @@
     </div>
 
     {{ else }}
-    <p><small><strong>Note:</strong> there are no HTML output for this widget</small></p>
+    <p><small><strong>Note:</strong> there is no HTML output for this widget</small></p>
     {{ end }}
 
     <h3>CSS classes</h3>


### PR DESCRIPTION
Add a message when the widget don't render anything instead of having the empty code block.

**Before**

![screen shot 2018-03-15 at 11 50 33](https://user-images.githubusercontent.com/6513513/37459202-a468597c-2847-11e8-8159-279c444ed1de.png)

**After**

![screen shot 2018-03-15 at 11 50 19](https://user-images.githubusercontent.com/6513513/37459207-a9451e12-2847-11e8-8dfb-2ba8b2d02ce8.png)