### PR TITLE
fix(panel): move button outside of header

### DIFF
--- a/content/widgets/panel.md
+++ b/content/widgets/panel.md
@@ -43,4 +43,6 @@ options:
     description: Text to put before the widget
   - name: footer
     description: Text to put after the widget
+  - name: collapsible
+    description: Makes the panel collapsible
 ---


### PR DESCRIPTION
In InstantSearch.js, the header is a template. Therefore we can't have
fixed markup such as a button unless we want people to modify. Also
templating makes it hard for us to add behavior such as collapsibility
on a button.

This moves the button out to solve this issue.