### PR TITLE
fix(geo): move default height in reset rather than theme

### DIFF
--- a/src/scss/themes/algolia.scss
+++ b/src/scss/themes/algolia.scss
@@ -161,11 +161,6 @@ a[class^='ais-'] {
   }
 }
 
-.ais-GeoSearch,
-.ais-GeoSearch-map {
-  height: 100%;
-}
-
 .ais-GeoSearch {
   position: relative;
 }

--- a/src/scss/themes/reset.scss
+++ b/src/scss/themes/reset.scss
@@ -65,6 +65,11 @@
   align-items: center;
 }
 
+.ais-GeoSearch,
+.ais-GeoSearch-map {
+  height: 100%;
+}
+
 .ais-HierarchicalMenu-list .ais-HierarchicalMenu-list {
   margin-left: 1em;
 }


### PR DESCRIPTION
**Summary**

This PR moves the height from the `theme` to the `reset`. It avoids the map to not be displayed when only the reset is loaded. Now the control / button are pushed out of the box model but at least the map is displayed. It won't be an issue because when the `reset` is used the user wants (most of the time) to use its own style.

**Before**

![screen shot 2018-07-16 at 12 21 07](https://user-images.githubusercontent.com/6513513/42753978-0625d0de-88f3-11e8-85ea-5f20e4c394ce.png)

**After**

![screen shot 2018-07-16 at 12 22 11](https://user-images.githubusercontent.com/6513513/42753980-08b094f6-88f3-11e8-9527-d98e67a36be1.png)