### PR TITLE
docs(pagination): Remove `transformItems()`

### DIFF
--- a/content/widgets/pagination.md
+++ b/content/widgets/pagination.md
@@ -73,6 +73,4 @@ options:
   - name: showPrevious
     default: true
     description: Whether to show the "previous page" control
-  - name: transformItems
-    description: Function which receives the items, which will be called before displaying them. Should return a new array with the same shape as the original array. Useful for mapping over the items to transform, remove or reorder them
 ---


### PR DESCRIPTION
There is no `transformItems()` on `Pagination`.

[See InstantSearch.js Pagination widget →](https://community.algolia.com/instantsearch.js/v2/widgets/pagination.html)