### PR TITLE
docs(stats): Remove `transformItems()`

### DIFF
--- a/content/widgets/stats.md
+++ b/content/widgets/stats.md
@@ -11,7 +11,4 @@ classes:
   - name: .ais-Stats-text
     description: the text of the widget
     description: the count of items for each item
-options:
-  - name: transformItems
-    description: Function which receives the items, which will be called before displaying them. Should return a new array with the same shape as the original array. Useful for mapping over the items to transform, remove or reorder them
 ---


### PR DESCRIPTION
This option doesn't exist for the Stats widget.