### PR TITLE
fix(select): add a max width

### DIFF
--- a/src/scss/themes/algolia.scss
+++ b/src/scss/themes/algolia.scss
@@ -305,6 +305,7 @@ a[class^='ais-'] {
 .ais-SortBy-select {
   appearance: none;
   padding: 0.3rem 2rem 0.3rem 0.3rem;
+  max-width: 100%;
   background-color: #fff;
   background-image: url('data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 24 24%27%3E%3Cpath d=%27M0 7.33l2.829-2.83 9.175 9.339 9.167-9.339 2.829 2.83-11.996 12.17z%27 fill%3D%22%233A4570%22 /%3E%3C/svg%3E');
   background-repeat: no-repeat;


### PR DESCRIPTION
If there's no limit, attribute values might cause it to overflow

## before
<img width="551" alt="screen shot 2018-09-12 at 09 25 37" src="https://user-images.githubusercontent.com/6270048/45439738-7415a200-b66f-11e8-9063-8a8f5a95da11.png">

## after
![screen shot 2018-09-12 at 09 25 31](https://user-images.githubusercontent.com/6270048/45439884-d4a4df00-b66f-11e8-9177-bb90dd1a7f56.png)

