### PR TITLE
fix: Geo control

### DIFF
--- a/src/scss/themes/algolia.scss
+++ b/src/scss/themes/algolia.scss
@@ -177,6 +177,7 @@ a[class^='ais-'] {
   background-color: #fff;
   border-radius: 5px;
   transition: background-color 0.2s ease-out;
+  box-shadow: rgba(0, 0, 0, 0.1) 0 1px 1px;
   outline: none;
 }
 


### PR DESCRIPTION
**Summary**

This PR update the Algolia theme to support the new Google Maps theme. I've also added a light shadow to have better view of the edges of the button.

**Before**

![screen shot 2018-09-17 at 13 56 42](https://user-images.githubusercontent.com/6513513/45622071-132d0600-ba83-11e8-92fd-61ede58a7dda.png)

**After**

![screen shot 2018-09-17 at 13 56 35](https://user-images.githubusercontent.com/6513513/45622077-16c08d00-ba83-11e8-95e9-460edbc8aff5.png)
