### PR TITLE
feat(highlight): change default tag

### DIFF
--- a/content/widgets/highlight.md
+++ b/content/widgets/highlight.md
@@ -2,7 +2,7 @@
 title: Highlight
 type: widget
 html: |
-  <span class="ais-Highlight"><span class="ais-Highlight-nonHighlighted">This is the</span> <em class="ais-Highlight-highlighted">highlighted text</em></span>
+  <span class="ais-Highlight"><span class="ais-Highlight-nonHighlighted">This is the</span> <mark class="ais-Highlight-highlighted">highlighted text</mark></span>
 classes:
   - name: .ais-Highlight
     description: the root span of the widget
@@ -12,6 +12,6 @@ classes:
     description: the normal text
 options:
   - name: highlightTag
-    default: em
+    default: mark
     description: DOM tag to use for the highlighted parts, in addition to the classes
 ---


### PR DESCRIPTION
While the engine default is `em`, the semantic version is `mark`. I went with `mark` in Vue InstantSearch v2, but this is obviously something only to change on a major version 