### PR TITLE
fix(geo): update Algolia theme

### DIFF
--- a/src/scss/themes/algolia.scss
+++ b/src/scss/themes/algolia.scss
@@ -182,6 +182,10 @@ a[class^='ais-'] {
   outline: none;
 }
 
+.ais-GeoSearch-input {
+  margin: 0 0.25rem 0 0;
+}
+
 .ais-GeoSearch-label,
 .ais-GeoSearch-redo,
 .ais-GeoSearch-reset {


### PR DESCRIPTION
**Summary**

The previous theme rely on the browser default (it's inconsistent) for the margin input. This PR reproduce the same with a fixed margin. I've also set the box model of the label to block. It fixes an issue where the button & label was not exactly at the same place.