### PR TITLE
fix(geo): update classes

### DIFF
--- a/content/widgets/geo-search.md
+++ b/content/widgets/geo-search.md
@@ -53,7 +53,7 @@ classes:
   - name: .ais-GeoSearch-label
     description: the label of the control element
   - name: .ais-GeoSearch-label--selected
-    description: the label of the control element
+    description: the selected label of the control element
   - name: .ais-GeoSearch-input
     description: the input of the control element
   - name: .ais-GeoSearch-redo


### PR DESCRIPTION
**Summary**

This PR adds the missing `selected` class for the label. It also removes the unused `disabled` class on reset. We don't use it because when the button is disabled it is not visible.