### PR TITLE
fix(CurrentRefinement): sync option name

### DIFF
--- a/content/widgets/current-refinements.md
+++ b/content/widgets/current-refinements.md
@@ -72,7 +72,7 @@ options:
     description: The list of attributes to display
   - name: excludedAttributes
     description: The list of attributes to filter out included attributes
-  - name: includesQuery
+  - name: clearsQuery
     default: false
     description: The list includes the query too
   - name: transformItems


### PR DESCRIPTION
Keep both option related to `query` in sync between `CurrentRefinements` and `ClearRefinements`.

- `CurrentRefinement`: `includesQuery` → `clearsQuery`
- `ClearRefinements`: `clearsQuery`