### PR TITLE
feat(infiniteHits): add previous button

### DIFF
--- a/content/widgets/infinite-hits.md
+++ b/content/widgets/infinite-hits.md
@@ -31,9 +31,42 @@ html: |
     </ol>
     <button class="ais-InfiniteHits-loadMore">Show more results</button>
   </div>
-alt1: Show more disabled
+alt1: Show previous enabled
 althtml1: |
   <div class="ais-InfiniteHits">
+    <button class="ais-InfiniteHits-loadPrevious">Show previous results</button>
+    <ul class="ais-InfiniteHits-list">
+      <li class="ais-InfiniteHits-item">
+        Hit 5477500: Amazon - Fire TV Stick with Alexa Voice Remote - Black
+      </li>
+      <li class="ais-InfiniteHits-item">
+        Hit 4397400: Google - Chromecast - Black
+      </li>
+      <li class="ais-InfiniteHits-item">
+        Hit 4397400: Google - Chromecast - Black
+      </li>
+      <li class="ais-InfiniteHits-item">
+        Hit 5477500: Amazon - Fire TV Stick with Alexa Voice Remote - Black
+      </li>
+      <li class="ais-InfiniteHits-item">
+        Hit 4397400: Google - Chromecast - Black
+      </li>
+      <li class="ais-InfiniteHits-item">
+        Hit 4397400: Google - Chromecast - Black
+      </li>
+      <li class="ais-InfiniteHits-item">
+        Hit 5477500: Amazon - Fire TV Stick with Alexa Voice Remote - Black
+      </li>
+      <li class="ais-InfiniteHits-item">
+        Hit 4397400: Google - Chromecast - Black
+      </li>
+    </ul>
+    <button class="ais-InfiniteHits-loadMore ais-InfiniteHits-loadMore--disabled" disabled>Show more results</button>
+  </div>
+alt2: Show previous and show more disabled
+althtml2: |
+  <div class="ais-InfiniteHits">
+    <button class="ais-InfiniteHits-loadPrevious ais-InfiniteHits-loadPrevious--disabled" disabled>Show previous results</button>
     <ul class="ais-InfiniteHits-list">
       <li class="ais-InfiniteHits-item">
         Hit 5477500: Amazon - Fire TV Stick with Alexa Voice Remote - Black
@@ -69,6 +102,10 @@ classes:
     description: the list of hits
   - name: .ais-InfiniteHits-item
     description: the hit list item
+  - name: .ais-InfiniteHits-loadPrevious
+    description: the button used to display previous results
+  - name: .ais-InfiniteHits-loadPrevious--disabled
+    description: the disabled button used to display previous results
   - name: .ais-InfiniteHits-loadMore
     description: the button used to display more results
   - name: .ais-InfiniteHits-loadMore--disabled

--- a/src/scss/themes/algolia.scss
+++ b/src/scss/themes/algolia.scss
@@ -80,6 +80,7 @@ a[class^='ais-'] {
 .ais-GeoSearch-redo,
 .ais-GeoSearch-reset,
 .ais-HierarchicalMenu-showMore,
+.ais-InfiniteHits-loadPrevious,
 .ais-InfiniteHits-loadMore,
 .ais-InfiniteResults-loadMore,
 .ais-Menu-showMore,
@@ -113,6 +114,10 @@ a[class^='ais-'] {
   &:focus {
     background-color: $algolia-blue;
   }
+}
+
+.ais-InfiniteHits-loadPrevious--disabled {
+  display: none;
 }
 
 .ais-CurrentRefinements {
@@ -302,6 +307,10 @@ a[class^='ais-'] {
 .ais-InfiniteHits-loadMore,
 .ais-InfiniteResults-loadMore {
   margin-top: 1rem;
+}
+
+.ais-InfiniteHits-loadPrevious {
+  margin-bottom: 1rem;
 }
 
 .ais-MenuSelect-select,

--- a/src/scss/themes/reset.scss
+++ b/src/scss/themes/reset.scss
@@ -26,6 +26,7 @@
 .ais-GeoSearch-redo,
 .ais-GeoSearch-reset,
 .ais-HierarchicalMenu-showMore,
+.ais-InfiniteHits-loadPrevious,
 .ais-InfiniteHits-loadMore,
 .ais-InfiniteResults-loadMore,
 .ais-Menu-showMore,


### PR DESCRIPTION
In https://github.com/algolia/instantsearch.js/pull/3645 we added a previous button to the [InfiniteHits widget](https://www.algolia.com/doc/api-reference/widgets/infinite-hits/js/).

For implementation details see [the full RFC](https://github.com/algolia/instantsearch-rfcs/blob/master/accepted/infinite-hits-previous-page.md).

This change adds new CSS classes for this button, those classes are:

* `.ais-InfiniteHits-loadPrevious`
* `.ais-InfiniteHits-loadPrevious--disabled` (has a `display:none` by default)

Additionaly the Instant Hits examples were updated to include some example with the previous button enabled ("Show previous enabled") and disabled ("Show previous and show more disabled").
