### PR TITLE
fix(satellite): update highlight color

### DIFF
--- a/src/scss/themes/satellite.scss
+++ b/src/scss/themes/satellite.scss
@@ -582,10 +582,9 @@ $red100: #ffe6e9;
 
 .ais-Highlight-highlighted,
 .ais-Snippet-highlighted {
-  background-color: $blue200;
-  color: inherit;
+  background-color: rgba($nebula500, 0.1);
+  color: $nebula500;
   font-style: normal;
-  font-weight: bold;
 }
 
 /**


### PR DESCRIPTION
In the end, we decided to go with the same highlight style as in the dashboard:

![image](https://user-images.githubusercontent.com/6137112/73379312-511a7b00-42c2-11ea-91c1-a86651db2f25.png)
