### PR TITLE
fix(satellite): max Search Box input width

### DIFF
--- a/src/scss/themes/satellite.scss
+++ b/src/scss/themes/satellite.scss
@@ -459,6 +459,7 @@ $red100: #ffe6e9;
   color: $grey900;
   flex: 1 1 0%;
   font: inherit;
+  max-width: 100%;
   padding-left: 2.5rem;
 }
 


### PR DESCRIPTION
The search box input overflows on small screens.

## Before

<img width="229" alt="Screenshot 2020-01-30 at 17 30 07" src="https://user-images.githubusercontent.com/6137112/73469428-a029e400-4386-11ea-9982-1e946875e52e.png">

## After

<img width="220" alt="Screenshot 2020-01-30 at 17 30 29" src="https://user-images.githubusercontent.com/6137112/73469429-a029e400-4386-11ea-9b5d-8c8988b8e54c.png">