### PR TITLE
fix(InfiniteHits): prevent scroll on buttons

### DIFF
--- a/src/scss/themes/reset.scss
+++ b/src/scss/themes/reset.scss
@@ -55,6 +55,13 @@
   }
 }
 
+// Prevent InfiniteHits buttons from moving scroll position
+// https://bugs.chromium.org/p/chromium/issues/detail?id=1110323
+.ais-InfiniteHits-loadPrevious,
+.ais-InfiniteHits-loadMore {
+  overflow-anchor: none;
+}
+
 // Reset widgets
 
 .ais-Breadcrumb-list,


### PR DESCRIPTION
When you click these buttons in latest Chrome, it will keep those buttons on the same place in the viewport, which means that users will skip the next page of results. With this property added, that's fixed.

This solution comes from https://bugs.chromium.org/p/chromium/issues/detail?id=1110323#c1 and has been verified by three customers so far.