### PR TITLE
fix(reset): add refinement's show more's also as `overflow-anchor: none`

### DIFF
--- a/src/scss/themes/reset.scss
+++ b/src/scss/themes/reset.scss
@@ -58,7 +58,10 @@
 // Prevent InfiniteHits buttons from moving scroll position
 // https://bugs.chromium.org/p/chromium/issues/detail?id=1110323
 .ais-InfiniteHits-loadPrevious,
-.ais-InfiniteHits-loadMore {
+.ais-InfiniteHits-loadMore,
+.ais-HierarchicalMenu-showMore,
+.ais-Menu-showMore,
+.ais-RefinementList-showMore {
   overflow-anchor: none;
 }
 


### PR DESCRIPTION
see https://discourse.algolia.com/t/infinitehits-load-more-button-doesnt-expand-container-correctly/10904/3 and https://github.com/algolia/instantsearch.js/issues/4495