### PR TITLE
fix(pagination): adjust pagination item spec

### DIFF
--- a/content/widgets/pagination.md
+++ b/content/widgets/pagination.md
@@ -10,7 +10,7 @@ html: |
       <li class="ais-Pagination-item ais-Pagination-item--previousPage ais-Pagination-item--disabled">
         <span class="ais-Pagination-link" aria-label="Previous">‹</span>
       </li>
-      <li class="ais-Pagination-item ais-Pagination-item--selected">
+      <li class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected">
         <a class="ais-Pagination-link" href="#">1</a>
       </li>
       <li class="ais-Pagination-item ais-Pagination-item--page">


### PR DESCRIPTION
This updates the spec for pagination item classes.

The `ais-Pagination-item--page` and `ais-Pagination-item--selected` modifiers shouldn't be mutually exclusive. Having `ais-Pagination-item--page` on all numeric items is useful because it lets you identify them (otherwise there's no way to differentiate between them and "First"/"Previous"/"Next"/"Last".

This is already how the InstantSearch.js `pagination` (and upcoming [`<Pagination>` in RISH](https://github.com/algolia/react-instantsearch/pull/3371)) is implemented. For reference, none of the InstantSearch flavors implement the spec the same way.