### PR TITLE
feat(pagination): suggest accessibility improvments

### DIFF
--- a/content/widgets/pagination.md
+++ b/content/widgets/pagination.md
@@ -3,7 +3,7 @@ title: Pagination
 type: widget
 html: |
   <div class="ais-Pagination">
-    <nav class="ais-Pagination-nav" aria-label="Pagination">
+    <nav class="ais-Pagination-navigation" aria-label="Pagination">
       <ul class="ais-Pagination-list">
         <li class="ais-Pagination-item ais-Pagination-item--firstPage ais-Pagination-item--disabled">
           <span class="ais-Pagination-link" aria-label="First">‹‹</span>

--- a/content/widgets/pagination.md
+++ b/content/widgets/pagination.md
@@ -3,32 +3,34 @@ title: Pagination
 type: widget
 html: |
   <div class="ais-Pagination">
-    <ul class="ais-Pagination-list">
-      <li class="ais-Pagination-item ais-Pagination-item--firstPage ais-Pagination-item--disabled">
-        <span class="ais-Pagination-link" aria-label="First">‹‹</span>
-      </li>
-      <li class="ais-Pagination-item ais-Pagination-item--previousPage ais-Pagination-item--disabled">
-        <span class="ais-Pagination-link" aria-label="Previous">‹</span>
-      </li>
-      <li class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected">
-        <a class="ais-Pagination-link" href="#">1</a>
-      </li>
-      <li class="ais-Pagination-item ais-Pagination-item--page">
-        <a class="ais-Pagination-link" href="#">2</a>
-      </li>
-      <li class="ais-Pagination-item ais-Pagination-item--page">
-        <a class="ais-Pagination-link" href="#">3</a>
-      </li>
-      <li class="ais-Pagination-item">
-        <a class="ais-Pagination-link" href="#">4</a>
-      </li>
-      <li class="ais-Pagination-item ais-Pagination-item--nextPage">
-        <a class="ais-Pagination-link" aria-label="Next" href="#">›</a>
-      </li>
-      <li class="ais-Pagination-item ais-Pagination-item--lastPage">
-        <a class="ais-Pagination-link" aria-label="Last" href="#">››</a>
-      </li>
-    </ul>
+    <nav class="ais-Pagination-nav" aria-label="Pagination">
+      <ul class="ais-Pagination-list">
+        <li class="ais-Pagination-item ais-Pagination-item--firstPage ais-Pagination-item--disabled">
+          <span class="ais-Pagination-link" aria-label="First">‹‹</span>
+        </li>
+        <li class="ais-Pagination-item ais-Pagination-item--previousPage ais-Pagination-item--disabled">
+          <span class="ais-Pagination-link" aria-label="Previous">‹</span>
+        </li>
+        <li class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected">
+          <span class="ais-Pagination-link" aria-label="Page 1, Current page" aria-current="page">1</span>
+        </li>
+        <li class="ais-Pagination-item ais-Pagination-item--page">
+          <a class="ais-Pagination-link" aria-label="Page 2" href="#">2</a>
+        </li>
+        <li class="ais-Pagination-item ais-Pagination-item--page">
+          <a class="ais-Pagination-link" aria-label="Page 3" href="#">3</a>
+        </li>
+        <li class="ais-Pagination-item">
+          <a class="ais-Pagination-link" aria-label="Page 4" href="#">4</a>
+        </li>
+        <li class="ais-Pagination-item ais-Pagination-item--nextPage">
+          <a class="ais-Pagination-link" aria-label="Next" href="#">›</a>
+        </li>
+        <li class="ais-Pagination-item ais-Pagination-item--lastPage">
+          <a class="ais-Pagination-link" aria-label="Last" href="#">››</a>
+        </li>
+      </ul>
+    <nav>
   </div>
 classes:
   - name: .ais-Pagination


### PR DESCRIPTION
The aria-label with page number was already implemented in most flavours, but is just the number.

https://www.a11ymatters.com/pattern/pagination/

We don't need aria-disabled as the disabled pages are already `span`, thus not interactive.

I'm suggesting this change to implement in React InstantSearch hooks initially, as it's not yet a breaking change there