### PR TITLE
feat(current-refinements): add norefinement modifier

### DIFF
--- a/content/widgets/current-refinements.md
+++ b/content/widgets/current-refinements.md
@@ -56,8 +56,6 @@ classes:
     description: the root div of the widget with no refinement
   - name: .ais-CurrentRefinements-list
     description: the list of all refined items
-  - name: .ais-CurrentRefinements-list--noRefinement
-    description: the list with no refinement
   - name: .ais-CurrentRefinements-item
     description: the refined list item
   - name: .ais-CurrentRefinements-label

--- a/content/widgets/current-refinements.md
+++ b/content/widgets/current-refinements.md
@@ -52,8 +52,12 @@ alt1: with empty excludedAttributes
 classes:
   - name: .ais-CurrentRefinements
     description: the root div of the widget
+  - name: .ais-CurrentRefinements--noRefinement
+    description: the root div of the widget with no refinement
   - name: .ais-CurrentRefinements-list
     description: the list of all refined items
+  - name: .ais-CurrentRefinements-list--noRefinement
+    description: the list with no refinement
   - name: .ais-CurrentRefinements-item
     description: the refined list item
   - name: .ais-CurrentRefinements-label


### PR DESCRIPTION
Following [this discussion](https://github.com/algolia/react-instantsearch/pull/3430#discussion_r854141280), this PR introduces 2 `--noRefinement` modifiers for the current refinements widget.

[**Preview →**](https://deploy-preview-122--instantsearch-css.netlify.app/widgets/current-refinements/#css-classes)