### PR TITLE
feat(hierarchical-menu): add selected class modifier for selected menu item link

### DIFF
--- a/content/widgets/hierarchical-menu.md
+++ b/content/widgets/hierarchical-menu.md
@@ -8,7 +8,7 @@ html: |
     </div>
     <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--lvl0">
       <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent ais-HierarchicalMenu-item--selected">
-        <a class="ais-HierarchicalMenu-link" href="#">
+        <a class="ais-HierarchicalMenu-link ais-HierarchicalMenu-link--selected" href="#">
           <span class="ais-HierarchicalMenu-label">Appliances</span>
           <span class="ais-HierarchicalMenu-count">4,306</span>
         </a>
@@ -44,7 +44,7 @@ althtml1: |
     </div>
     <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--lvl0">
       <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--parent ais-HierarchicalMenu-item--selected">
-        <a class="ais-HierarchicalMenu-link" href="#">
+        <a class="ais-HierarchicalMenu-link ais-HierarchicalMenu-link--selected" href="#">
           <span class="ais-HierarchicalMenu-label">Appliances</span>
           <span class="ais-HierarchicalMenu-count">4,306</span>
         </a>
@@ -95,6 +95,8 @@ classes:
     description: the menu list item containing children
   - name: .ais-HierarchicalMenu-link
     description: the clickable menu element
+  - name: .ais-HierarchicalMenu-link--selected
+    description: the clickable menu element of a selected menu list item
   - name: .ais-HierarchicalMenu-label
     description: the label of each item
   - name: .ais-HierarchicalMenu-count


### PR DESCRIPTION
This PR adds a `--selected` class modifier to the link of a refined hierarchical menu item, that allows users to apply styles on the link only, and not the whole container (including sublevel items if they exist).

Before | After
------- | -----
`.ais-HierarchicalMenu-item--selected { font-weight: bold }` | `.ais-HierarchicalMenu-link--selected { font-weight: bold }`
<img width="255" alt="image" src="https://user-images.githubusercontent.com/154633/193060359-1d3304c4-5354-43fc-9950-6c81e96ad4be.png"> | <img width="255" alt="image" src="https://user-images.githubusercontent.com/154633/193060261-c8a1b7ec-c8df-4873-b9d3-38224e42f3e5.png">

 
> **Note**
> This PR does not change the already existing CSS for the link of a refined menu item.


[FX-1736](https://algolia.atlassian.net/browse/FX-1736)