### PR TITLE
chore: update README with migration notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,7 @@
 # InstantSearch.css and specs
 
-> **Note**
->
-> **InstantSearch.css has a new home 👋**
->
-> This project has moved and is now part of the [InstantSearch monorepo](https://github.com/algolia/instantsearch.js)! The library remains unchanged and is still available as `instantsearch.css` on [npm](https://www.npmjs.com/package/instantsearch.css) and CDNs like [jsDelivr](https://www.jsdelivr.com/package/npm/instantsearch.css).
->
-> You can [browse the code](https://github.com/algolia/instantsearch.js/tree/master/packages/instantsearch.css), find [existing issues](https://github.com/algolia/instantsearch.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22Package%3A+instantsearch.css%22) and follow [new releases](https://github.com/algolia/instantsearch.js/releases) over there.
+## InstantSearch.css has a new home 👋
 
-## Installation
+This project has moved and is now part of the [InstantSearch monorepo](https://github.com/algolia/instantsearch.js)! The library remains unchanged and is still available as `instantsearch.css` on [npm](https://www.npmjs.com/package/instantsearch.css) and CDNs like [jsDelivr](https://www.jsdelivr.com/package/npm/instantsearch.css).
 
-```
-yarn
-```
-
-## Launch demo site + assets
-
-```
-yarn dev
-```
-
-Available at http://localhost:1313
-
-## Build demo site + assets
-
-```
-yarn build
-```
-
-## Release a new version
-
-Make your changes, commit them and:
-
-```
-npm version (major|minor|patch) -m "Version x.x.x"
-npm publish
-git push origin <tag_name>
-```
-
-## Implemented versions
-
-InstantSearch.css is a living standard. This table tracks down the version implemented in each InstantSearch:
-
-| Project | Version |
-| ------- | ------- |
-| Angular | 7       |
-| React   | 7       |
-| Vanilla | 7       |
-| Vue     | 7       |
+You can [browse the code](https://github.com/algolia/instantsearch.js/tree/master/packages/instantsearch.css), find [existing issues](https://github.com/algolia/instantsearch.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22Package%3A+instantsearch.css%22) and follow [new releases](https://github.com/algolia/instantsearch.js/releases) over there.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# InstantSearch.css and specs
-
-## InstantSearch.css has a new home 👋
+# InstantSearch.css has a new home 👋
 
 This project has moved and is now part of the [InstantSearch monorepo](https://github.com/algolia/instantsearch.js)! The library remains unchanged and is still available as `instantsearch.css` on [npm](https://www.npmjs.com/package/instantsearch.css) and CDNs like [jsDelivr](https://www.jsdelivr.com/package/npm/instantsearch.css).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # InstantSearch.css and specs
 
+> **Note**
+>
+> **InstantSearch.css has a new home 👋**
+>
+> This project has moved and is now part of the [InstantSearch monorepo](https://github.com/algolia/instantsearch.js)! The library remains unchanged and is still available as `instantsearch.css` on [npm](https://www.npmjs.com/package/instantsearch.css) and CDNs like [jsDelivr](https://www.jsdelivr.com/package/npm/instantsearch.css).
+>
+> You can [browse the code](https://github.com/algolia/instantsearch.js/tree/master/packages/instantsearch.css), find [existing issues](https://github.com/algolia/instantsearch.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22Package%3A+instantsearch.css%22) and follow [new releases](https://github.com/algolia/instantsearch.js/releases) over there.
+
 ## Installation
 
 ```


### PR DESCRIPTION
This adds a banner to let users know the package has moved.

[**Preview →**](https://github.com/algolia/instantsearch-specs/tree/chore/migration-notice#readme)

[FX-2113](https://algolia.atlassian.net/browse/FX-2113)